### PR TITLE
Only load one HIAD model at a time

### DIFF
--- a/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
+++ b/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
@@ -166,7 +166,7 @@ PART
 	}
 	MODULE
 	{
-		name = ModuleAnimateGeneric
+		name = ModuleAnimateGeneric:NEEDS[ReStock]
 		animationName = Inflate
 		isOneShot = false
 		startEventGUIName = Inflate Heat Shield (ReStock)

--- a/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
+++ b/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
@@ -124,7 +124,7 @@ PART
 		CORE
 		{
 			variant = Heatshield
-			model = HIAD-Stock
+			model:NEEDS[!ReStock] = HIAD-Stock
 			model:NEEDS[ReStock] = HIAD-ReStock
 		}
 
@@ -151,27 +151,27 @@ PART
 	}
 
 	//ReStock and Squad use different animation names
-	//So, make two animate modules. It's not pretty, but it works...
-	MODULE
+	//only load the appropriate one to avoid drag cube issues I guess
+	MODULE:NEEDS[!ReStock]
 	{
 		name = ModuleAnimateGeneric
 		animationName = InflatableHS
 		isOneShot = false
-		startEventGUIName = Inflate Heat Shield (Squad)
-		endEventGUIName = Deflate Heat Shield (Squad)
-		actionGUIName = Inflate Heat Shield (Squad)
+		startEventGUIName = Inflate Heat Shield
+		endEventGUIName = Deflate Heat Shield
+		actionGUIName = Inflate Heat Shield
 		allowAnimationWhileShielded = False
 		restrictedNode = top
 		disableAfterPlaying = false
 	}
-	MODULE
+	MODULE:NEEDS[ReStock]
 	{
-		name = ModuleAnimateGeneric:NEEDS[ReStock]
+		name = ModuleAnimateGeneric
 		animationName = Inflate
 		isOneShot = false
-		startEventGUIName = Inflate Heat Shield (ReStock)
-		endEventGUIName = Deflate Heat Shield (ReStock)
-		actionGUIName = Inflate Heat Shield (ReStock)
+		startEventGUIName = Inflate Heat Shield
+		endEventGUIName = Deflate Heat Shield
+		actionGUIName = Inflate Heat Shield
 		allowAnimationWhileShielded = False
 		restrictedNode = top
 		disableAfterPlaying = false

--- a/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
+++ b/GameData/ROHeatshields/Parts/AdjustableHIAD.cfg
@@ -115,7 +115,8 @@ PART
 		currentDiameter = 10.0
 		currentVariant = Heatshield
 		currentNose = Model-None
-		currentCore = HIAD-Stock
+		currentCore:NEEDS[!ReStock] = HIAD-Stock
+		currentCore:NEEDS[ReStock] = HIAD-ReStock
 		currentMount = Model-None
 		currentNoseTexture = default
 		currentCoreTexture = default
@@ -161,7 +162,7 @@ PART
 		endEventGUIName = Deflate Heat Shield
 		actionGUIName = Inflate Heat Shield
 		allowAnimationWhileShielded = False
-		restrictedNode = top
+		//restrictedNode = bottom	//eh, let people do weird stuff with it
 		disableAfterPlaying = false
 	}
 	MODULE:NEEDS[ReStock]
@@ -173,7 +174,7 @@ PART
 		endEventGUIName = Deflate Heat Shield
 		actionGUIName = Inflate Heat Shield
 		allowAnimationWhileShielded = False
-		restrictedNode = top
+		//restrictedNode = bottom	//eh, let people do weird stuff with it
 		disableAfterPlaying = false
 	}
 


### PR DESCRIPTION
Due to drag cube reasons, just disable the stock module if ReStock is present (and vice versa)