### PR TITLE
VScale fixes

### DIFF
--- a/Source/ModuleROHeatshield.cs
+++ b/Source/ModuleROHeatshield.cs
@@ -50,7 +50,10 @@ namespace ROHeatshields
 
         public float CurrentDiameter => modularPart?.currentDiameter ?? 0f;
         public float CurrentVScale => modularPart?.currentVScale ?? 0f;
-        public float HeatShieldMass => (ActivePreset.massOverride > 0 ? -origMass + ActivePreset.massOverride : 0) + Mathf.Pow(CurrentDiameter, 2.0f) * HeatShieldDensity;
+        public float HeatShieldMass =>
+            (ActivePreset.massOverride > 0 ? -origMass + ActivePreset.massOverride : 0) +
+            (ActivePreset.disableModAblator ? (CurrentVScale + 2) / 2 : 1.0f) *
+            Mathf.Pow(CurrentDiameter, 2.0f) * HeatShieldDensity;
         // Ablator = Round( D² * density * (vScale + 2)/2 )
         public float HeatShieldAblator => Mathf.Round(Mathf.Pow(CurrentDiameter, 2.0f) * ActivePreset.heatShieldAblator * ((CurrentVScale + 2) / 2) * 10f) / 10f;
 

--- a/Source/ModuleROHeatshield.cs
+++ b/Source/ModuleROHeatshield.cs
@@ -168,12 +168,13 @@ namespace ROHeatshields
 
         #region Custom Methods
 
-        public void UpdateHeatshieldValues()
+        public void UpdateHeatshieldValues(bool updateAblatorInFlight = false)
         {
             hsMass = HeatShieldMass;
             hsCost = HeatShieldCost;
 
-            if (modularPart != null && modAblator != null && modAblator.enabled)
+            if ((HighLogic.LoadedSceneIsEditor || updateAblatorInFlight) &&
+                modularPart != null && modAblator != null && modAblator.enabled)
             {
                 if (ablatorResourceName != null)
                 {
@@ -276,6 +277,7 @@ namespace ROHeatshields
                     modAblator.nominalAmountRecip = p.NominalAmountRecip.Value;
             }
 
+            bool updateAblatorInFlight = false;
             if (modAblator != null)
             {
                 if (p.AblativeResource == null || ablatorResourceName != p.AblativeResource ||
@@ -283,6 +285,7 @@ namespace ROHeatshields
                     p.disableModAblator)
                 {
                     RemoveAblatorResources();
+                    updateAblatorInFlight = true;
                 }
 
                 ablatorResourceName = p.AblativeResource;
@@ -307,7 +310,7 @@ namespace ROHeatshields
                 Fields[nameof(description)].guiActiveEditor = false;
 
             Debug.Log($"[ROHeatshields] loaded preset {p.name} for part {part.name}");
-            UpdateHeatshieldValues();
+            UpdateHeatshieldValues(updateAblatorInFlight);
         }
 
         public void ResetPartToOriginal()


### PR DESCRIPTION
- Scale the mass of Ablator-less heatshields with VScale
- Make ablator with VScale, instead of (VScale + 2)/2
- Don't update the ablator amount while in-flight
- Minor formatting changes

Fixes the mass part of #19